### PR TITLE
Add install.config.json for mget one-line installs

### DIFF
--- a/install.config.json
+++ b/install.config.json
@@ -1,0 +1,13 @@
+{
+  "schema_version": 1,
+  "project_name": "refract",
+  "github_repo": "RefractMC/Refract_MC",
+  "manifest_url": "https://github.com/RefractMC/Refract_MC/releases/latest/download/latest.json",
+  "pubkey": "RWQkukf1kBwQ/86ivJEv75SqjTY69a/ygF8HPb9ZXNwQoi+A2L/dY875",
+  "macos_bundle_name": "Refract",
+  "macos_executable_name": "refract-tauri",
+  "deb_package_name": "refract",
+  "rpm_package_name": "refract",
+  "install_dir": "$HOME/.local/bin",
+  "install_url": "https://refractmc.net/install.sh"
+}


### PR DESCRIPTION
Adds an `install.config.json` at the repo root that describes Refract to the shared [mget](https://github.com/modrexio/mget) install engine, enabling a one-line install on Linux/macOS:

```sh
curl -fsSL https://refractmc.net/install.sh | sh
```

## What the config provides

The mget engine is project-agnostic; everything Refract-specific lives in this one file:

- `github_repo` / `manifest_url` - where releases and the Tauri updater manifest (`latest.json`) live
- `pubkey` - the minisign public key used to verify release signatures before install
- `macos_bundle_name` / `macos_executable_name`, `deb_package_name`, `rpm_package_name` - per-platform artifact naming
- `install_dir` - defaults to `$HOME/.local/bin`
- `install_url` - the canonical installer URL, echoed by the engine in self-update instructions

## How it fits together

This is the same config contract Modrex uses for its own `modrex.net/install.sh` installer. The `install.sh` stub served from refractmc.net (companion PR in RefractMC/Refract_net) fetches this file from `main` at install time, exports the fields as `CFG_*` environment variables, and hands over to the mget engine. Config changes here take effect on the next install with no redeploy of the website.

`schema_version: 1` is checked by the engine so a future breaking change to the config format fails loudly instead of misinstalling.
