### PR TITLE
i18n: refine blocked-mod and verify strings in zh-CN translation

### DIFF
--- a/locales/zh-CN.json
+++ b/locales/zh-CN.json
@@ -316,7 +316,7 @@
     "byAuthor": "作者：{{name}}",
     "installedOkStats": "{{name}} 已安装，用时 {{stats}}",
     "blockedTitle": "需要手动下载",
-    "blockedBody": "{{name}} 的作者仅允许从 CurseForge 网站下载。Refract 将在浏览器中打开下载页面，监视“下载”文件夹中的文件，校验后自动安装。",
+    "blockedBody": "{{name}} 的作者仅允许从 CurseForge 网站下载。Refract 将在浏览器中打开下载页面，监测“下载”文件夹中的文件，校验后自动安装。",
     "blockedStart": "打开浏览器并安装",
     "blockedWaitingStart": "等待浏览器下载…",
     "blockedWaiting": "等待浏览器下载… 剩余 {{s}} 秒",
@@ -725,7 +725,7 @@
     "verifyFiles": "校验文件",
     "verifying": "校验中…",
     "repairFiles": "修复",
-    "verifyAllOk": "已校验全部 {{n}} 个跟踪文件 — 未发现问题。",
+    "verifyAllOk": "已校验全部 {{n}} 个文件 — 未发现问题。",
     "verifyIssues": "{{n}} 个文件缺失或损坏。",
     "verifyRepaired": "已修复 {{total}} 个损坏文件中的 {{n}} 个。"
   },


### PR DESCRIPTION
## Refine two zh-CN strings from the downloads update

The `feat(downloads)` commit (`b2efee6`) added Simplified Chinese translations alongside the new download-engine strings. Two of them read awkwardly, so this tweaks them.

### `browse.blockedBody`

`监视` → `监测`

`监视` reads as snooping/surveillance in Chinese. The string is about Refract watching the Downloads folder for a file, so "Refract will 监视 your Downloads folder" sounds like the app is spying on the user. `监测` is just the neutral technical term for file monitoring.

### `instanceDetail.verifyAllOk`

`跟踪文件` → `文件`

`跟踪` in Chinese is more like "tailing/stalking a person", not "tracking files". And `跟踪文件` is ambiguous (could read as "files that do the tracking"). Dropping it to just `文件` is clear enough in context.