### PR TITLE
Add eLink install links

### DIFF
--- a/apps/renderer/package.json
+++ b/apps/renderer/package.json
@@ -20,6 +20,7 @@
     "@tanstack/react-query": "^5.51.1",
     "@tanstack/react-router": "^1.170.15",
     "@tauri-apps/api": "^2.11.0",
+    "@tauri-apps/plugin-deep-link": "^2.4.9",
     "@tauri-apps/plugin-dialog": "^2.7.1",
     "@tauri-apps/plugin-process": "^2.3.1",
     "@tauri-apps/plugin-updater": "^2.10.1",

--- a/apps/renderer/src/renderer/src/components/layout/AppShell.tsx
+++ b/apps/renderer/src/renderer/src/components/layout/AppShell.tsx
@@ -5,6 +5,7 @@ import { Info, X } from 'lucide-react'
 import { TitleBar } from './TitleBar'
 import { Sidebar } from './Sidebar'
 import { StatusBar } from './StatusBar'
+import { InstallFromLinkDialog } from '@/components/sharing/InstallFromLinkDialog'
 import { api, supportsWindowResizeDragging } from '@/lib/api'
 import { useT } from '@/i18n'
 
@@ -148,6 +149,7 @@ export function AppShell({ children }: { children: ReactNode }) {
       zIndex: 1,
     }}>
       {supportsWindowResizeDragging && <WindowResizeHandles />}
+      <InstallFromLinkDialog />
       <div
         aria-hidden="true"
         className="chrome-top-fill"

--- a/apps/renderer/src/renderer/src/components/sharing/InstallFromLinkDialog.tsx
+++ b/apps/renderer/src/renderer/src/components/sharing/InstallFromLinkDialog.tsx
@@ -1,0 +1,158 @@
+import * as Dialog from '@radix-ui/react-dialog'
+import { useNavigate } from '@tanstack/react-router'
+import { Link2, X } from 'lucide-react'
+import { useEffect, useRef, useState } from 'react'
+import { Button } from '@/components/ui/Button'
+import { useT } from '@/i18n'
+import {
+  deliverShareTarget,
+  onOpenInstallFromLink,
+  resolveShareInput,
+  routeForShareTarget,
+  type ResolvedShareTarget,
+} from '@/lib/share-link'
+
+const handledDeepLinks = new Set<string>()
+
+export function InstallFromLinkDialog() {
+  const t = useT()
+  const navigate = useNavigate()
+  const [open, setOpen] = useState(false)
+  const [input, setInput] = useState('')
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [target, setTarget] = useState<ResolvedShareTarget | null>(null)
+  const inputRef = useRef<HTMLInputElement>(null)
+
+  async function resolve(value = input) {
+    setLoading(true)
+    setError(null)
+    setTarget(null)
+    try {
+      setTarget(await resolveShareInput(value))
+    } catch (cause) {
+      setError(cause instanceof Error ? cause.message : t.sharing.invalid)
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  function receive(value: string) {
+    setInput(value)
+    setTarget(null)
+    setError(null)
+    setOpen(true)
+    if (value) void resolve(value)
+  }
+
+  useEffect(() => onOpenInstallFromLink(receive), [])
+
+  useEffect(() => {
+    let unlisten: (() => void) | undefined
+    let cancelled = false
+
+    const handleUrls = (urls: string[]) => {
+      const url = urls.find(candidate => candidate.startsWith('refract://'))
+      if (!url || handledDeepLinks.has(url)) return
+      handledDeepLinks.add(url)
+      receive(url)
+    }
+
+    void import('@tauri-apps/plugin-deep-link')
+      .then(async ({ getCurrent, onOpenUrl }) => {
+        if (cancelled) return
+        handleUrls((await getCurrent()) ?? [])
+        unlisten = await onOpenUrl(handleUrls)
+        if (cancelled) unlisten()
+      })
+      .catch(() => { /* browser preview has no native deep-link plugin */ })
+
+    return () => {
+      cancelled = true
+      unlisten?.()
+    }
+  }, [])
+
+  function continueToInstall() {
+    if (!target) return
+    deliverShareTarget(target)
+    void navigate({ to: routeForShareTarget(target) })
+    setOpen(false)
+  }
+
+  const targetIcon = target
+    ? target.provider === 'curseforge' ? target.project.logo?.thumbnailUrl : target.project.icon_url
+    : null
+  const targetName = target
+    ? target.provider === 'curseforge' ? target.project.name : target.project.title
+    : ''
+
+  return (
+    <Dialog.Root open={open} onOpenChange={(next) => { if (!loading) setOpen(next) }}>
+      <Dialog.Portal>
+        <Dialog.Overlay className="theme-overlay" />
+        <Dialog.Content
+          className="ni-dialog"
+          aria-describedby="elink-description"
+          onOpenAutoFocus={(event) => { event.preventDefault(); inputRef.current?.focus() }}
+          style={{ zIndex: 10001, width: 'min(520px, calc(100vw - 32px))', maxHeight: 'calc(100dvh - 48px)', overflow: 'hidden' }}
+        >
+          <div className="ni-dialog-header" style={{ display: 'flex', alignItems: 'center', gap: 13, padding: '18px 20px', borderBottom: '1px solid var(--border-r)' }}>
+            <div style={{ width: 36, height: 36, borderRadius: 'var(--radius-md)', display: 'grid', placeItems: 'center', color: 'var(--accent)', background: 'color-mix(in srgb, var(--accent) 13%, var(--surface-2))' }}>
+              <Link2 size={18} aria-hidden="true" />
+            </div>
+            <div style={{ minWidth: 0, flex: 1 }}>
+              <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+                <Dialog.Title style={{ margin: 0, fontSize: 16, color: 'var(--ink)' }}>{t.sharing.title}</Dialog.Title>
+                <span style={{ padding: '2px 6px', borderRadius: 999, fontSize: 9, fontWeight: 800, letterSpacing: '.08em', color: 'var(--accent)', background: 'color-mix(in srgb, var(--accent) 12%, transparent)' }}>{t.sharing.beta}</span>
+              </div>
+              <Dialog.Description id="elink-description" style={{ margin: '3px 0 0', color: 'var(--ink-3)', fontSize: 12 }}>{t.sharing.subtitle}</Dialog.Description>
+            </div>
+            <Dialog.Close asChild>
+              <Button variant="ghost" size="icon" aria-label={t.sharing.cancel}><X size={16} /></Button>
+            </Dialog.Close>
+          </div>
+
+          <form onSubmit={(event) => { event.preventDefault(); void resolve() }} style={{ padding: 20, display: 'flex', flexDirection: 'column', gap: 14 }}>
+            <label style={{ display: 'flex', flexDirection: 'column', gap: 7, fontSize: 12, fontWeight: 700, color: 'var(--ink-2)' }}>
+              {t.sharing.inputLabel}
+              <input
+                ref={inputRef}
+                value={input}
+                onChange={(event) => { setInput(event.target.value); setTarget(null); setError(null) }}
+                placeholder={t.sharing.placeholder}
+                autoComplete="off"
+                spellCheck={false}
+                style={{ height: 40, padding: '0 12px', borderRadius: 'var(--radius-sm)', border: `1px solid ${error ? 'var(--danger)' : 'var(--border-r)'}`, background: 'var(--surface-2)', color: 'var(--ink)', outline: 'none', fontSize: 13 }}
+              />
+            </label>
+
+            {error && <div role="alert" style={{ padding: '10px 12px', borderRadius: 'var(--radius-sm)', color: 'var(--danger)', background: 'color-mix(in srgb, var(--danger) 10%, transparent)', fontSize: 12 }}>{error}</div>}
+
+            {target && (
+              <div style={{ display: 'grid', gridTemplateColumns: '44px minmax(0, 1fr)', gap: 12, alignItems: 'center', padding: 12, border: '1px solid var(--border-r)', borderRadius: 'var(--radius-md)', background: 'var(--surface-2)' }}>
+                {targetIcon ? (
+                  <img src={targetIcon} alt="" style={{ width: 44, height: 44, borderRadius: 'var(--radius-sm)', objectFit: 'cover' }} />
+                ) : <div style={{ width: 44, height: 44, borderRadius: 'var(--radius-sm)', display: 'grid', placeItems: 'center', background: 'var(--surface-3)', color: 'var(--ink-4)' }}><Link2 size={17} /></div>}
+                <div style={{ minWidth: 0 }}>
+                  <div style={{ fontSize: 13, fontWeight: 750, color: 'var(--ink)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{targetName}</div>
+                  <div style={{ marginTop: 3, fontSize: 11, color: 'var(--ink-3)', textTransform: 'capitalize' }}>{target.provider} ? {target.kind}</div>
+                  <div style={{ marginTop: 5, fontSize: 11, color: 'var(--ink-4)' }}>{t.sharing.ready}</div>
+                </div>
+              </div>
+            )}
+
+            <div style={{ display: 'flex', justifyContent: 'flex-end', gap: 8 }}>
+              <Dialog.Close asChild><Button variant="ghost" disabled={loading}>{t.sharing.cancel}</Button></Dialog.Close>
+              {!target ? (
+                <Button variant="primary" type="submit" disabled={loading || !input.trim()}>{loading ? t.sharing.resolving : t.sharing.resolve}</Button>
+              ) : (
+                <Button variant="primary" onClick={continueToInstall}>{t.sharing.continue}</Button>
+              )}
+            </div>
+          </form>
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
+  )
+}

--- a/apps/renderer/src/renderer/src/i18n/index.ts
+++ b/apps/renderer/src/renderer/src/i18n/index.ts
@@ -195,6 +195,7 @@ function build(l: Locale) {
       instances: (n: number) => i(n !== 1 ? l.sync.instanceCountPlural : l.sync.instanceCount, { n }),
     },
 
+    sharing: { ...l.sharing },
     migration: { ...l.migration },
     privacy: { ...l.privacy },
   }

--- a/apps/renderer/src/renderer/src/lib/share-link.ts
+++ b/apps/renderer/src/renderer/src/lib/share-link.ts
@@ -1,0 +1,201 @@
+import type { CFProject, ModrinthProject, ModrinthProjectType } from '@refract/core'
+import { getModrinthProject } from '@refract/core'
+import { api } from '@/lib/api'
+
+export type ShareProvider = 'modrinth' | 'curseforge'
+export type ShareKind = ModrinthProjectType
+
+export interface ShareReference {
+  provider?: ShareProvider
+  kind?: ShareKind
+  key: string
+}
+
+export type ResolvedShareTarget =
+  | { provider: 'modrinth'; kind: ModrinthProjectType; project: ModrinthProject }
+  | { provider: 'curseforge'; kind: 'mod' | 'modpack'; project: CFProject }
+
+const SAFE_KEY = /^[A-Za-z0-9_-]{1,96}$/
+const OPEN_EVENT = 'refract:open-install-link'
+const TARGET_EVENT = 'refract:resolved-install-link'
+let pendingTarget: ResolvedShareTarget | null = null
+
+function safeKey(value: string | null): string {
+  const key = (value ?? '').trim()
+  if (!SAFE_KEY.test(key)) throw new Error('Project slug or ID contains unsupported characters.')
+  return key
+}
+
+function modrinthKind(value: string): ModrinthProjectType | undefined {
+  return value === 'mod' || value === 'modpack' || value === 'resourcepack' || value === 'shader' || value === 'datapack'
+    ? value
+    : undefined
+}
+
+function curseForgeKind(value: string): 'mod' | 'modpack' | undefined {
+  if (value === 'mc-mods' || value === 'mods' || value === 'mod') return 'mod'
+  if (value === 'modpacks' || value === 'modpack') return 'modpack'
+  return undefined
+}
+
+function parseWebUrl(url: URL): ShareReference {
+  const host = url.hostname.toLowerCase().replace(/^www\./, '')
+  const parts = url.pathname.split('/').filter(Boolean)
+
+  if (host === 'modrinth.com') {
+    const kind = modrinthKind(parts[0] ?? '')
+    if (!kind || !parts[1]) throw new Error('Use a Modrinth project page URL.')
+    return { provider: 'modrinth', kind, key: safeKey(parts[1]) }
+  }
+
+  if (host === 'curseforge.com') {
+    if (parts[0] !== 'minecraft') throw new Error('Only Minecraft CurseForge links are supported.')
+    const kind = curseForgeKind(parts[1] ?? '')
+    if (!kind || !parts[2]) throw new Error('Use a CurseForge mod or modpack page URL.')
+    return { provider: 'curseforge', kind, key: safeKey(parts[2]) }
+  }
+
+  throw new Error('Only Modrinth and CurseForge project links are supported.')
+}
+
+function parseRefractUrl(url: URL): ShareReference {
+  if (url.hostname !== 'install') throw new Error('This Refract link is not an install link.')
+
+  const nestedUrl = url.searchParams.get('url')
+  if (nestedUrl) {
+    let parsed: URL
+    try { parsed = new URL(nestedUrl) } catch { throw new Error('The embedded project URL is invalid.') }
+    if (parsed.protocol !== 'https:') throw new Error('Embedded project URLs must use HTTPS.')
+    return parseWebUrl(parsed)
+  }
+
+  const parts = url.pathname.split('/').filter(Boolean)
+  const providerValue = (url.searchParams.get('source') ?? url.searchParams.get('provider') ?? parts[0] ?? '').toLowerCase()
+  const provider = providerValue === 'modrinth' || providerValue === 'curseforge' ? providerValue : undefined
+  if (!provider) throw new Error('The Refract link has an unsupported project source.')
+
+  const rawKind = (url.searchParams.get('type') ?? parts[1] ?? '').toLowerCase()
+  const kind = provider === 'modrinth' ? modrinthKind(rawKind) : curseForgeKind(rawKind)
+  if (!kind) throw new Error('The Refract link has an unsupported project type.')
+
+  return {
+    provider,
+    kind,
+    key: safeKey(url.searchParams.get('slug') ?? url.searchParams.get('id') ?? parts[2] ?? null),
+  }
+}
+
+export function parseShareInput(raw: string): ShareReference {
+  const input = raw.trim()
+  if (!input) throw new Error('Paste a project URL, slug, or Refract install link.')
+
+  if (SAFE_KEY.test(input)) return { key: input }
+
+  let url: URL
+  try { url = new URL(input) } catch { throw new Error('Enter a valid project URL or project slug.') }
+
+  if (url.username || url.password || url.port) throw new Error('This URL format is not supported.')
+  if (url.protocol === 'refract:') return parseRefractUrl(url)
+  if (url.protocol !== 'https:') throw new Error('Project links must use HTTPS.')
+  return parseWebUrl(url)
+}
+
+function normalizeModrinthProject(detail: Awaited<ReturnType<typeof getModrinthProject>>): ModrinthProject {
+  return {
+    project_id: detail.id,
+    slug: detail.slug,
+    title: detail.title,
+    description: detail.description,
+    categories: detail.categories,
+    downloads: detail.downloads,
+    follows: detail.followers,
+    icon_url: detail.icon_url,
+    versions: detail.versions,
+    loaders: detail.loaders,
+    game_versions: detail.game_versions,
+    project_type: detail.project_type,
+    date_created: detail.published,
+    date_modified: detail.updated,
+  }
+}
+
+async function resolveModrinth(reference: ShareReference): Promise<ResolvedShareTarget> {
+  const detail = await getModrinthProject(reference.key)
+  if (reference.kind && detail.project_type !== reference.kind) {
+    throw new Error(`This project is a ${detail.project_type}, not a ${reference.kind}.`)
+  }
+  return { provider: 'modrinth', kind: detail.project_type, project: normalizeModrinthProject(detail) }
+}
+
+async function resolveCurseForge(reference: ShareReference): Promise<ResolvedShareTarget> {
+  if (reference.kind !== 'mod' && reference.kind !== 'modpack') {
+    throw new Error('CurseForge links must identify a mod or modpack.')
+  }
+
+  if (/^\d+$/.test(reference.key)) {
+    const project = await api.curseforge.projectDetail(Number(reference.key))
+    const expectedClassId = reference.kind === 'modpack' ? 4471 : 6
+    if (project.classId !== expectedClassId) {
+      throw new Error(`This CurseForge project is not a ${reference.kind}.`)
+    }
+    return { provider: 'curseforge', kind: reference.kind, project }
+  }
+
+  const result = reference.kind === 'modpack'
+    ? await api.curseforge.searchModpacks(reference.key, undefined, 20, 0)
+    : await api.curseforge.searchMods(reference.key, undefined, undefined, 20, 0)
+  const project = result.data.find(item => item.slug.toLowerCase() === reference.key.toLowerCase())
+  if (!project) throw new Error('CurseForge project not found. Check the slug and your API key.')
+  return { provider: 'curseforge', kind: reference.kind, project }
+}
+
+export async function resolveShareInput(raw: string): Promise<ResolvedShareTarget> {
+  const reference = parseShareInput(raw)
+  if (reference.provider === 'curseforge') return resolveCurseForge(reference)
+  if (reference.provider === 'modrinth') return resolveModrinth(reference)
+
+  try {
+    return await resolveModrinth(reference)
+  } catch {
+    for (const kind of ['modpack', 'mod'] as const) {
+      try { return await resolveCurseForge({ ...reference, provider: 'curseforge', kind }) } catch { /* try the next source */ }
+    }
+    throw new Error('No Modrinth or CurseForge project matched that slug or ID.')
+  }
+}
+
+export function createInstallDeepLink(target: ResolvedShareTarget): string {
+  return `refract://install/${target.provider}/${target.kind}/${encodeURIComponent(target.project.slug)}`
+}
+
+export function openInstallFromLink(input = ''): void {
+  window.dispatchEvent(new CustomEvent<string>(OPEN_EVENT, { detail: input }))
+}
+
+export function onOpenInstallFromLink(listener: (input: string) => void): () => void {
+  const handler = (event: Event) => listener((event as CustomEvent<string>).detail ?? '')
+  window.addEventListener(OPEN_EVENT, handler)
+  return () => window.removeEventListener(OPEN_EVENT, handler)
+}
+
+export function routeForShareTarget(target: ResolvedShareTarget): '/browse' | '/modpacks' {
+  return target.kind === 'mod' ? '/browse' : '/modpacks'
+}
+
+export function deliverShareTarget(target: ResolvedShareTarget): void {
+  pendingTarget = target
+  window.dispatchEvent(new CustomEvent<ResolvedShareTarget>(TARGET_EVENT, { detail: target }))
+}
+
+export function consumeShareTarget(route: '/browse' | '/modpacks'): ResolvedShareTarget | null {
+  if (!pendingTarget || routeForShareTarget(pendingTarget) !== route) return null
+  const target = pendingTarget
+  pendingTarget = null
+  return target
+}
+
+export function onShareTarget(listener: (target: ResolvedShareTarget) => void): () => void {
+  const handler = (event: Event) => listener((event as CustomEvent<ResolvedShareTarget>).detail)
+  window.addEventListener(TARGET_EVENT, handler)
+  return () => window.removeEventListener(TARGET_EVENT, handler)
+}

--- a/apps/renderer/src/renderer/src/routes/browse/index.tsx
+++ b/apps/renderer/src/renderer/src/routes/browse/index.tsx
@@ -1,6 +1,7 @@
 ﻿import { createFileRoute } from '@tanstack/react-router'
 import { useState, useEffect, useRef, useMemo } from 'react'
 import type React from 'react'
+import { Link2 } from 'lucide-react'
 import { SearchIcon } from '@/components/ui/BlockIcons'
 import { Button } from '@/components/ui/Button'
 import { CardGridSkeleton, TextSkeleton } from '@/components/ui/Skeleton'
@@ -9,6 +10,7 @@ import { htmlToText } from '@/lib/sanitize'
 import type { ModrinthProject, ModrinthVersion, ModrinthSortIndex, Instance, CFProject, CFFile, CFProjectDetail, ResolvedDep } from '@refract/core'
 import { useScrollLock } from '@/lib/use-scroll-lock'
 import { useT } from '@/i18n'
+import { consumeShareTarget, onShareTarget, openInstallFromLink, type ResolvedShareTarget } from '@/lib/share-link'
 
 export const Route = createFileRoute('/browse/')({
   component: Browse,
@@ -970,6 +972,31 @@ function Browse() {
   const [blockedTarget, setBlockedTarget] = useState<BlockedModError | null>(null)
 
   const searchRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  useEffect(() => {
+    const applyTarget = (target: ResolvedShareTarget) => {
+      if (target.kind !== 'mod') return
+      setQuery(target.project.slug)
+      setOffset(0)
+      if (target.provider === 'modrinth') {
+        setSource('mr')
+        setResults([target.project])
+        setDetailTarget(target.project)
+      } else {
+        setSource('cf')
+        setCfAvailable(true)
+        setCfResults([target.project])
+        setCfModDetail(target.project)
+      }
+    }
+
+    const initial = consumeShareTarget('/browse')
+    if (initial) applyTarget(initial)
+    return onShareTarget((target) => {
+      if (target.kind !== 'mod') return
+      applyTarget(consumeShareTarget('/browse') ?? target)
+    })
+  }, [])
+
 
   // Feature 3: suggested instance for empty-query recommendations
   const suggested = useMemo(() => {
@@ -1267,6 +1294,9 @@ function Browse() {
           <h1 style={{ fontSize: 20, fontWeight: 700, color: 'var(--ink)', margin: '0 0 3px' }}>{t.browse.title}</h1>
           <p style={{ fontSize: 13, color: 'var(--ink-3)', margin: 0 }}>{t.browse.subtitle}</p>
         </div>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 8, flexShrink: 0 }}>
+          <Button variant="outline" onClick={() => openInstallFromLink()} style={{ height: 32, gap: 7, padding: '0 10px', fontSize: 11 }}><Link2 size={14} />{t.sharing.open}<span style={{ fontSize: 8, fontWeight: 800, letterSpacing: '.08em', color: 'var(--accent)' }}>{t.sharing.beta}</span></Button>
+
         {/* Source toggle */}
         <div style={{ display: 'flex', background: 'var(--surface)', border: '1px solid var(--border-r)', borderRadius: 'var(--radius-md)', padding: 3, gap: 3, flexShrink: 0 }}>
           {(['mr', 'cf'] as const).map(src => (
@@ -1284,6 +1314,7 @@ function Browse() {
               {src === 'mr' ? t.browse.sourceMr : t.browse.sourceCf}
             </Button>
           ))}
+        </div>
         </div>
       </div>
 

--- a/apps/renderer/src/renderer/src/routes/modpacks/index.tsx
+++ b/apps/renderer/src/renderer/src/routes/modpacks/index.tsx
@@ -1,6 +1,7 @@
 ﻿import { createFileRoute } from '@tanstack/react-router'
 import { useState, useEffect, useRef, useCallback } from 'react'
 import type React from 'react'
+import { Link2 } from 'lucide-react'
 import { SearchIcon } from '@/components/ui/BlockIcons'
 import { Button } from '@/components/ui/Button'
 import { CardGridSkeleton, TextSkeleton } from '@/components/ui/Skeleton'
@@ -10,6 +11,7 @@ import type { ModrinthProject, ModrinthVersion, ModrinthSortIndex, ModrinthProje
 import { ftbIconUrl, ftbTargets } from '@refract/core'
 import { useScrollLock } from '@/lib/use-scroll-lock'
 import { useT } from '@/i18n'
+import { consumeShareTarget, onShareTarget, openInstallFromLink, type ResolvedShareTarget } from '@/lib/share-link'
 
 export const Route = createFileRoute('/modpacks/')({ component: ContentBrowser })
 
@@ -1212,6 +1214,33 @@ function ContentBrowser() {
   }
 
   const searchRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  useEffect(() => {
+    const applyTarget = (target: ResolvedShareTarget) => {
+      if (target.kind === 'mod') return
+      setQuery(target.project.slug)
+      setOffset(0)
+      if (target.provider === 'modrinth') {
+        setTab(target.kind)
+        setCfSource('modrinth')
+        setResults([target.project])
+        setDetailTarget(target.project)
+      } else {
+        setTab('modpack')
+        setCfSource('curseforge')
+        setCfHasKey(true)
+        setCfResults([target.project])
+        setCfDetail(target.project)
+      }
+    }
+
+    const initial = consumeShareTarget('/modpacks')
+    if (initial) applyTarget(initial)
+    return onShareTarget((target) => {
+      if (target.kind === 'mod') return
+      applyTarget(consumeShareTarget('/modpacks') ?? target)
+    })
+  }, [])
+
   const tabInfo   = TABS.find(ti => ti.type === tab)!
   const installedModrinthInstances = new Map(
     instances
@@ -1397,6 +1426,7 @@ function ContentBrowser() {
           <h1 style={{ fontSize: 20, fontWeight: 700, color: 'var(--ink)', margin: '0 0 3px' }}>{t.content.title}</h1>
           <p style={{ fontSize: 13, color: 'var(--ink-3)', margin: 0 }}>{t.content.subtitle}</p>
         </div>
+        <Button variant="outline" onClick={() => openInstallFromLink()} style={{ height: 32, gap: 7, padding: '0 10px', fontSize: 11 }}><Link2 size={14} />{t.sharing.open}<span style={{ fontSize: 8, fontWeight: 800, letterSpacing: '.08em', color: 'var(--accent)' }}>{t.sharing.beta}</span></Button>
       </div>
 
       {/* Type tabs + source toggle */}

--- a/apps/tauri/src-tauri/Cargo.lock
+++ b/apps/tauri/src-tauri/Cargo.lock
@@ -116,6 +116,137 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
+name = "async-broadcast"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "435a87a52755b8f27fcf321ac4f04b2802e337c8c4872923137471ec39c37532"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-channel"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
+dependencies = [
+ "concurrent-queue",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-executor"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c96bf972d85afc50bf5ab8fe2d54d1586b4e0b46c97c50a0c9e71e2f7bcd812a"
+dependencies = [
+ "async-task",
+ "concurrent-queue",
+ "fastrand",
+ "futures-lite",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
+name = "async-io"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "456b8a8feb6f42d237746d4b3e9a178494627745c3c56c6ea55d92ba50d026fc"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "concurrent-queue",
+ "futures-io",
+ "futures-lite",
+ "parking",
+ "polling",
+ "rustix",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "async-lock"
+version = "3.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290f7f2596bd5b78a9fec8088ccd89180d7f9f55b94b0576823bbbdc72ee8311"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-process"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc50921ec0055cdd8a16de48773bfeec5c972598674347252c0399676be7da75"
+dependencies = [
+ "async-channel",
+ "async-io",
+ "async-lock",
+ "async-signal",
+ "async-task",
+ "blocking",
+ "cfg-if",
+ "event-listener",
+ "futures-lite",
+ "rustix",
+]
+
+[[package]]
+name = "async-recursion"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "async-signal"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52b5aaafa020cf5053a01f2a60e8ff5dccf550f0f77ec54a4e47285ac2bab485"
+dependencies = [
+ "async-io",
+ "async-lock",
+ "atomic-waker",
+ "cfg-if",
+ "futures-core",
+ "futures-io",
+ "rustix",
+ "signal-hook-registry",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "async-task"
+version = "4.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
+
+[[package]]
+name = "async-trait"
+version = "0.1.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "atk"
 version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -264,6 +395,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
 dependencies = [
  "objc2",
+]
+
+[[package]]
+name = "blocking"
+version = "1.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e83f8d02be6967315521be875afa792a316e28d57b5a2d401897e2a7921b7f21"
+dependencies = [
+ "async-channel",
+ "async-task",
+ "futures-io",
+ "futures-lite",
+ "piper",
 ]
 
 [[package]]
@@ -526,10 +670,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
+name = "const-random"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87e00182fe74b066627d63b85fd550ac2998d4b0bd86bfed477a0ae4c7c71359"
+dependencies = [
+ "const-random-macro",
+]
+
+[[package]]
+name = "const-random-macro"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9d839f2a20b0aee515dc581a6172f2321f96cab76c1a38a4c584a194955390e"
+dependencies = [
+ "getrandom 0.2.17",
+ "once_cell",
+ "tiny-keccak",
+]
 
 [[package]]
 name = "constant_time_eq"
@@ -949,7 +1122,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1007,6 +1180,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "dlv-list"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "442039f5147480ba31067cb00ada1adae6892028e40e45fc5de7b7df6dcc1b5f"
+dependencies = [
+ "const-random",
 ]
 
 [[package]]
@@ -1152,6 +1334,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ef6b89e5b37196644d8796de5268852ff179b44e96276cf4290264843743bb7"
 
 [[package]]
+name = "endi"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66b7e2430c6dff6a955451e2cfc438f09cea1965a9d6f87f7e3b90decc014099"
+
+[[package]]
+name = "enumflags2"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1027f7680c853e056ebcec683615fb6fbbc07dbaa13b4d5d9442b146ded4ecef"
+dependencies = [
+ "enumflags2_derive",
+ "serde",
+]
+
+[[package]]
+name = "enumflags2_derive"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67c78a4d8fdf9953a5c9d458f9efe940fd97a0cab0941c075a813ac594733827"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1175,7 +1384,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "event-listener"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
+dependencies = [
+ "event-listener",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -1343,6 +1573,19 @@ name = "futures-io"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+
+[[package]]
+name = "futures-lite"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad"
+dependencies = [
+ "fastrand",
+ "futures-core",
+ "futures-io",
+ "parking",
+ "pin-project-lite",
+]
 
 [[package]]
 name = "futures-macro"
@@ -1710,6 +1953,12 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+
+[[package]]
+name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
@@ -1745,6 +1994,12 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hex"
@@ -2608,7 +2863,7 @@ dependencies = [
  "png 0.18.1",
  "serde",
  "thiserror 2.0.18",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2932,6 +3187,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
+name = "ordered-multimap"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49203cdcae0030493bad186b28da2fa25645fa276a51b6fec8010d281e02ef79"
+dependencies = [
+ "dlv-list",
+ "hashbrown 0.14.5",
+]
+
+[[package]]
+name = "ordered-stream"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aa2b01e1d916879f73a53d01d1d6cee68adbb31d6d9177a8cfce093cced1d50"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "osakit"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2969,6 +3244,12 @@ dependencies = [
  "libc",
  "system-deps",
 ]
+
+[[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
 name = "parking_lot"
@@ -3075,6 +3356,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
+name = "piper"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c835479a4443ded371d6c535cbfd8d31ad92c5d23ae9770a61bc155e4992a3c1"
+dependencies = [
+ "atomic-waker",
+ "fastrand",
+ "futures-io",
+]
+
+[[package]]
 name = "pkcs8"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3127,6 +3419,20 @@ dependencies = [
  "fdeflate",
  "flate2",
  "miniz_oxide",
+]
+
+[[package]]
+name = "polling"
+version = "3.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218"
+dependencies = [
+ "cfg-if",
+ "concurrent-queue",
+ "hermit-abi",
+ "pin-project-lite",
+ "rustix",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3485,8 +3791,10 @@ dependencies = [
  "tar",
  "tauri",
  "tauri-build",
+ "tauri-plugin-deep-link",
  "tauri-plugin-dialog",
  "tauri-plugin-process",
+ "tauri-plugin-single-instance",
  "tauri-plugin-updater",
  "tokio",
  "uuid",
@@ -3672,6 +3980,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rust-ini"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "796e8d2b6696392a43bea58116b667fb4c29727dc5abd27d6acf338bb4f688c7"
+dependencies = [
+ "cfg-if",
+ "ordered-multimap",
+]
+
+[[package]]
 name = "rustc-hash"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3696,7 +4014,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3753,7 +4071,7 @@ dependencies = [
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4168,6 +4486,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
+name = "signal-hook-registry"
+version = "1.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
+dependencies = [
+ "errno",
+ "libc",
+]
+
+[[package]]
 name = "signature"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4224,7 +4552,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4649,6 +4977,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-deep-link"
+version = "2.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70ee75bc5627f77bfdf40c913255ebc258117b10ebe2b2239a1a1cf40b0b58aa"
+dependencies = [
+ "dunce",
+ "plist",
+ "rust-ini",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "tauri-utils",
+ "thiserror 2.0.18",
+ "tracing",
+ "url",
+ "windows-registry",
+ "windows-result 0.3.4",
+]
+
+[[package]]
 name = "tauri-plugin-dialog"
 version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4698,6 +5047,23 @@ checksum = "d55511a7bf6cd70c8767b02c97bf8134fa434daf3926cfc1be0a0f94132d165a"
 dependencies = [
  "tauri",
  "tauri-plugin",
+]
+
+[[package]]
+name = "tauri-plugin-single-instance"
+version = "2.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3214becf9ef5783c0ae99a3bb25adf5353a7a16ebf53e74b909e29205735c6c"
+dependencies = [
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin-deep-link",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "windows-sys 0.60.2",
+ "zbus",
 ]
 
 [[package]]
@@ -4843,7 +5209,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5169,7 +5535,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5200,7 +5578,7 @@ dependencies = [
  "png 0.18.1",
  "serde",
  "thiserror 2.0.18",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5226,6 +5604,17 @@ name = "typenum"
 version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
+
+[[package]]
+name = "uds_windows"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
+dependencies = [
+ "memoffset 0.9.1",
+ "tempfile",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "unic-char-property"
@@ -5745,7 +6134,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5883,6 +6272,17 @@ checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
 dependencies = [
  "windows-core 0.61.2",
  "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-registry"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b8a9ed28765efc97bbc954883f4e6796c33a06546ebafacbabee9696967499e"
+dependencies = [
+ "windows-link 0.1.3",
+ "windows-result 0.3.4",
+ "windows-strings 0.4.2",
 ]
 
 [[package]]
@@ -6519,6 +6919,67 @@ dependencies = [
 ]
 
 [[package]]
+name = "zbus"
+version = "5.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a28b97f866896a4be7aefd2b5a8e01bb6773d19a775d54ab28b4d094b9a4480e"
+dependencies = [
+ "async-broadcast",
+ "async-executor",
+ "async-io",
+ "async-lock",
+ "async-process",
+ "async-recursion",
+ "async-task",
+ "async-trait",
+ "blocking",
+ "enumflags2",
+ "event-listener",
+ "futures-core",
+ "futures-lite",
+ "hex",
+ "libc",
+ "ordered-stream",
+ "rustix",
+ "serde",
+ "serde_repr",
+ "tracing",
+ "uds_windows",
+ "uuid",
+ "windows-sys 0.61.2",
+ "winnow 1.0.3",
+ "zbus_macros",
+ "zbus_names",
+ "zvariant",
+]
+
+[[package]]
+name = "zbus_macros"
+version = "5.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e05ad887425eecf5e8384dc2406a4a9313eb73468712fc1cdea362eb4fe0469"
+dependencies = [
+ "proc-macro-crate 3.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "zbus_names",
+ "zvariant",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zbus_names"
+version = "4.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1039ca249fee9559680f3a9f05b55e0761fee51af4f6c1e7d8c1f31e549721d2"
+dependencies = [
+ "serde",
+ "winnow 1.0.3",
+ "zvariant",
+]
+
+[[package]]
 name = "zerocopy"
 version = "0.8.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6734,4 +7195,44 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27bc9d5b815bc103f142aa054f561d9187d191692ec7c2d1e2b4737f8dbd7296"
 dependencies = [
  "zune-core",
+]
+
+[[package]]
+name = "zvariant"
+version = "5.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cf057bb00bf5c9ad77abb6147b0ca4818236a1858416e9d988e40d6322fefa7"
+dependencies = [
+ "endi",
+ "enumflags2",
+ "serde",
+ "winnow 1.0.3",
+ "zvariant_derive",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zvariant_derive"
+version = "5.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8118ca6bda77bfc0ab51d660db0c955f2505eef854c9a449435bccb616933b31"
+dependencies = [
+ "proc-macro-crate 3.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zvariant_utils"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90cb9383f9b45290407a1258b202d3f8f01db719eb60b4e4055c6375af4fc7c7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde",
+ "syn 2.0.117",
+ "winnow 1.0.3",
 ]

--- a/apps/tauri/src-tauri/Cargo.toml
+++ b/apps/tauri/src-tauri/Cargo.toml
@@ -17,6 +17,8 @@ tauri = { version = "2", features = [] }
 tauri-plugin-dialog = "2"
 tauri-plugin-updater = "2"
 tauri-plugin-process = "2"
+tauri-plugin-deep-link = "2"
+tauri-plugin-single-instance = { version = "2", features = ["deep-link"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 dirs = "5"

--- a/apps/tauri/src-tauri/capabilities/default.json
+++ b/apps/tauri/src-tauri/capabilities/default.json
@@ -15,6 +15,8 @@
     "dialog:allow-open",
     "dialog:allow-save",
     "updater:default",
-    "process:allow-restart"
+    "process:allow-restart",
+    "core:event:default",
+    "deep-link:default"
   ]
 }

--- a/apps/tauri/src-tauri/src/lib.rs
+++ b/apps/tauri/src-tauri/src/lib.rs
@@ -41,10 +41,25 @@ pub fn run() {
     }
 
     tauri::Builder::default()
+        .plugin(tauri_plugin_single_instance::init(|app, _args, _cwd| {
+            use tauri::Manager as _;
+            if let Some(window) = app.get_webview_window("main") {
+                let _ = window.show();
+                let _ = window.unminimize();
+                let _ = window.set_focus();
+            }
+        }))
+        .plugin(tauri_plugin_deep_link::init())
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_updater::Builder::new().build())
         .plugin(tauri_plugin_process::init())
         .setup(|app| {
+            #[cfg(any(target_os = "linux", all(debug_assertions, target_os = "windows")))]
+            {
+                use tauri_plugin_deep_link::DeepLinkExt as _;
+                app.deep_link().register_all()?;
+            }
+
             analytics::init();
             // Some Linux WMs (notably Wayland compositors) ignore the initial
             // state of frameless windows and open them at minimum content

--- a/apps/tauri/src-tauri/tauri.conf.json
+++ b/apps/tauri/src-tauri/tauri.conf.json
@@ -32,6 +32,11 @@
     "updater": {
       "endpoints": ["https://github.com/RefractMC/Refract_MC/releases/latest/download/latest.json"],
       "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IEZGMTAxQzkwRjU0N0JBMjQKUldRa3VrZjFrQndRLzg2aXZKRXY3NVNxalRZNjlhL3lnRjhIUGI5WlhOd1FvaStBMkwvZFk4NzUK"
+    },
+    "deep-link": {
+      "desktop": {
+        "schemes": ["refract"]
+      }
     }
   },
   "bundle": {

--- a/locales/en.json
+++ b/locales/en.json
@@ -780,6 +780,20 @@
     "legendLink": "launches from the original folder, mods stay in sync automatically",
     "legendImport": "copies mods/saves/configs into Refract (independent)"
   },
+  "sharing": {
+    "title": "eLink",
+    "beta": "BETA",
+    "open": "Install from link",
+    "subtitle": "Paste a Modrinth or CurseForge project URL, project slug, or refract:// link.",
+    "inputLabel": "Project URL or slug",
+    "placeholder": "https://modrinth.com/modpack/...",
+    "resolve": "Find project",
+    "resolving": "Finding...",
+    "continue": "Open install",
+    "cancel": "Cancel",
+    "ready": "Ready to continue in Refract's existing install flow.",
+    "invalid": "Could not resolve this link."
+  },
   "migration": {
     "title": "Refract 1.2.0 update",
     "body": "Your launcher data is preserved after the Tauri upgrade. Microsoft accounts need a one-time sign-in again; offline accounts continue to work.",

--- a/packages/core/src/modrinth/index.ts
+++ b/packages/core/src/modrinth/index.ts
@@ -21,6 +21,23 @@ export interface ModrinthProject {
   date_modified?: string
 }
 
+export interface ModrinthProjectDetail {
+  id: string
+  slug: string
+  title: string
+  description: string
+  categories: string[]
+  downloads: number
+  followers: number
+  icon_url: string | null
+  versions: string[]
+  loaders: string[]
+  game_versions: string[]
+  project_type: ModrinthProjectType
+  published: string
+  updated: string
+}
+
 export interface ModrinthSearchOptions {
   query?: string
   projectType?: ModrinthProjectType
@@ -110,6 +127,13 @@ export async function searchContent(opts: ModrinthSearchOptions): Promise<Modrin
   const res = await fetch(`${BASE}/search?${params}`)
   if (!res.ok) throw new Error(`Modrinth search failed: ${res.status}`)
   return res.json() as Promise<ModrinthSearchResult>
+}
+
+/** Resolve a Modrinth project by either its public slug or project ID. */
+export async function getModrinthProject(projectIdOrSlug: string): Promise<ModrinthProjectDetail> {
+  const res = await fetch(`${BASE}/project/${encodeURIComponent(projectIdOrSlug)}`)
+  if (!res.ok) throw new Error(`Modrinth project not found: ${res.status}`)
+  return res.json() as Promise<ModrinthProjectDetail>
 }
 
 export async function getProjectVersions(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -81,6 +81,9 @@ importers:
       '@tauri-apps/api':
         specifier: ^2.11.0
         version: 2.11.0
+      '@tauri-apps/plugin-deep-link':
+        specifier: ^2.4.9
+        version: 2.4.9
       '@tauri-apps/plugin-dialog':
         specifier: ^2.7.1
         version: 2.7.1
@@ -1123,6 +1126,9 @@ packages:
     resolution: {integrity: sha512-bk3HemqvGRoy+5D/dVMUQHKMYLglD0jVnMm/0iGMH6ufZ+p8r14m6BpIixwij3PBvZdvORUp1YifTD8QxVZ1Nw==}
     engines: {node: '>= 10'}
     hasBin: true
+
+  '@tauri-apps/plugin-deep-link@2.4.9':
+    resolution: {integrity: sha512-u0SKOUHnJ1wqeqXsDFq2+kASCBj9xxbG0g9XZWPy9SOmU4wXtp6b/wiYpm6oH6/5fBTQsLqnLhIvqLBRpgHJlA==}
 
   '@tauri-apps/plugin-dialog@2.7.1':
     resolution: {integrity: sha512-OK1UBXYt+ojcmxMktzzuyonYIFta8CmAASpX+CA+DTGK24KlHjhYI6x2iOJ/TjZF4N7/ACK1oFmEOjIY9IhzOQ==}
@@ -4174,6 +4180,10 @@ snapshots:
       '@tauri-apps/cli-win32-arm64-msvc': 2.11.2
       '@tauri-apps/cli-win32-ia32-msvc': 2.11.2
       '@tauri-apps/cli-win32-x64-msvc': 2.11.2
+
+  '@tauri-apps/plugin-deep-link@2.4.9':
+    dependencies:
+      '@tauri-apps/api': 2.11.0
 
   '@tauri-apps/plugin-dialog@2.7.1':
     dependencies:


### PR DESCRIPTION
## What changed

- add the eLink Beta install-from-link dialog for Modrinth and CurseForge URLs or slugs
- register `refract://install/...` desktop deep links with single-instance forwarding
- route resolved projects into the existing mod, modpack, resource pack, shader, and datapack install flows
- validate accepted hosts, schemes, project types, IDs, and slugs
- keep the eLink dialog above its blur overlay

## Why

Refract needs a receiving-side sharing flow so project links can open directly in the launcher without duplicating its existing install and dependency handling.

## Validation

- `pnpm --filter @refract/renderer typecheck`
- `pnpm --filter @refract/tauri-poc build:real`
- `cargo check`
- changed Rust entry-file formatting check
- JSON configuration validation
- `git diff --check`