### PR TITLE
docs: introduce docs/ directory with Simplified Chinese README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,10 @@
 </p>
 
 <p align="center">
+  🌐 <a href="docs/README.zh-CN.md">简体中文</a>
+</p>
+
+<p align="center">
   Organize instances, discover community content, manage Java, and launch Minecraft from one focused desktop app.
 </p>
 
@@ -171,6 +175,7 @@ project conventions, and pull request guidelines.
 * `packages/core` contains shared launcher logic.
 * `packages/plugin-api` contains the public plugin API.
 * `locales` contains translation files.
+* `docs` contains project documentation.
 
 </details>
 

--- a/docs/README.zh-CN.md
+++ b/docs/README.zh-CN.md
@@ -1,0 +1,197 @@
+<p align="center">
+  <img src="../logo/refract-iris-256.png" width="112" alt="Refract 标志" />
+</p>
+
+<h1 align="center">Refract</h1>
+
+<p align="center">
+  <strong>基于 Tauri 和 React 构建的快速、开源 Minecraft 启动器。</strong>
+</p>
+
+<p align="center">
+  🌐 <a href="../README.md">English</a>
+</p>
+
+<p align="center">
+  整理实例、发现社区内容、管理 Java、启动 Minecraft…一个应用就够了！
+</p>
+
+<p align="center">
+  <a href="https://github.com/RefractMC/Refract_MC/releases/latest">
+    <img src="https://img.shields.io/github/v/release/RefractMC/Refract_MC?style=flat-square&color=5316D4" alt="最新版本" />
+  </a>
+  <a href="https://github.com/RefractMC/Refract_MC/releases">
+    <img src="https://img.shields.io/github/downloads/RefractMC/Refract_MC/total?style=flat-square&color=5316D4" alt="总下载量" />
+  </a>
+  <a href="../LICENSE">
+    <img src="https://img.shields.io/github/license/RefractMC/Refract_MC?style=flat-square&color=5316D4" alt="GPL-3.0 许可证" />
+  </a>
+  <a href="https://github.com/RefractMC/Refract_MC/actions/workflows/development-builds.yml">
+    <img src="https://img.shields.io/github/actions/workflow/status/RefractMC/Refract_MC/development-builds.yml?branch=main&style=flat-square&label=builds&color=5316D4" alt="开发构建状态" />
+  </a>
+  <a href="https://github.com/RefractMC/Refract_MC/actions/workflows/security-audit.yml">
+    <img src="https://img.shields.io/github/actions/workflow/status/RefractMC/Refract_MC/security-audit.yml?branch=main&style=flat-square&label=security&color=5316D4" alt="安全审计状态" />
+  </a>
+</p>
+
+<p align="center">
+  <a href="https://refractmc.net"><strong>官网</strong></a>
+  &nbsp;&nbsp;|&nbsp;&nbsp;
+  <a href="https://github.com/RefractMC/Refract_MC/releases/latest"><strong>最新版本</strong></a>
+  &nbsp;&nbsp;|&nbsp;&nbsp;
+  <a href="https://discord.gg/tE8s5VaWmS"><strong>Discord</strong></a>
+  &nbsp;&nbsp;|&nbsp;&nbsp;
+  <a href="../CONTRIBUTING.md"><strong>参与贡献</strong></a>
+</p>
+
+<p align="center">
+  <a href="https://github.com/RefractMC/Refract_MC/releases/latest">
+    <img src="https://i.postimg.cc/s27G22Qv/Screenshot-2026-07-10-192249.png" width="100%" alt="Refract 启动器截图" />
+  </a>
+</p>
+
+## 为你的 Minecraft 实例库而生
+
+<table>
+  <tr>
+    <td width="50%" valign="top">
+      <strong>井井有条的实例管理</strong><br />
+      创建、分组、复制、导出、置顶、搜索和筛选实例。
+      自由选择安装路径，并导入已有的 MultiMC 或 Prism 实例库。
+    </td>
+    <td width="50%" valign="top">
+      <strong>无需打开浏览器即可获取内容</strong><br />
+      从 Modrinth 或 CurseForge 安装模组、整合包、光影、资源包和数据包。
+      排序、更新并保存可复用的模组档案。
+    </td>
+  </tr>
+  <tr>
+    <td width="50%" valign="top">
+      <strong>触手可及的玩家工具</strong><br />
+      管理世界和备份，浏览截图，实时追踪服务器状态，并为每个实例单独控制资源包和光影。
+    </td>
+    <td width="50%" valign="top">
+      <strong>自动处理账户与 Java</strong><br />
+      使用 Microsoft、离线或 Yggdrasil 账户。Refract 会查找或下载正确的 Java 运行时，并提供可选的性能预设。
+    </td>
+  </tr>
+</table>
+
+Refract 还包含自动更新、崩溃报告复制、可自定义主题、Discord Rich Presence 以及 Java Edition 许可证验证。
+
+## 下载
+
+### Linux 和 macOS 安装脚本
+
+```sh
+curl -fsSL https://refractmc.net/install.sh | sh
+```
+
+### 直接下载
+
+<p align="center">
+  <a href="https://github.com/RefractMC/Refract_MC/releases/latest/download/Refract-Windows-x64.exe">
+    <img src="https://img.shields.io/badge/Download-Windows-5316D4?style=for-the-badge&logo=windows11&logoColor=white" alt="下载 Refract Windows 版" />
+  </a>
+  <a href="https://github.com/RefractMC/Refract_MC/releases/latest/download/Refract-macOS-arm64.dmg">
+    <img src="https://img.shields.io/badge/macOS-Apple_Silicon-5316D4?style=for-the-badge&logo=apple&logoColor=white" alt="下载 Refract Apple Silicon macOS 版" />
+  </a>
+  <a href="https://github.com/RefractMC/Refract_MC/releases/latest/download/Refract-macOS-x64.dmg">
+    <img src="https://img.shields.io/badge/macOS-Intel-5316D4?style=for-the-badge&logo=apple&logoColor=white" alt="下载 Refract Intel macOS 版" />
+  </a>
+  <a href="https://github.com/RefractMC/Refract_MC/releases/latest/download/Refract-Linux-x86_64.AppImage">
+    <img src="https://img.shields.io/badge/Linux-AppImage-5316D4?style=for-the-badge&logo=linux&logoColor=white" alt="下载 Refract Linux AppImage 版" />
+  </a>
+</p>
+
+| 平台                   | 下载包                                                                                                                 |
+| ---------------------- | ---------------------------------------------------------------------------------------------------------------------- |
+| Windows 10/11          | [下载 `.exe`](https://github.com/RefractMC/Refract_MC/releases/latest/download/Refract-Windows-x64.exe)                |
+| macOS — Apple Silicon  | [下载 ARM64 `.dmg`](https://github.com/RefractMC/Refract_MC/releases/latest/download/Refract-macOS-arm64.dmg)          |
+| macOS — Intel          | [下载 Intel `.dmg`](https://github.com/RefractMC/Refract_MC/releases/latest/download/Refract-macOS-x64.dmg)            |
+| Linux — AppImage       | [下载 `.AppImage`](https://github.com/RefractMC/Refract_MC/releases/latest/download/Refract-Linux-x86_64.AppImage)     |
+| Linux — Debian/Ubuntu  | [下载 `.deb`](https://github.com/RefractMC/Refract_MC/releases/latest/download/Refract-Linux-amd64.deb)                |
+| Linux — Fedora         | [下载 `.rpm`](https://github.com/RefractMC/Refract_MC/releases/latest/download/Refract-Linux-x86_64.rpm)               |
+| Linux — Arch/AUR       | [`yay -S refract-launcher-bin`](https://aur.archlinux.org/packages/refract-launcher-bin)                               |
+| 其他包                 | [查看最新版本](https://github.com/RefractMC/Refract_MC/releases/latest)                                                 |
+
+> [!NOTE]
+> macOS 构建目前未签名。首次启动时，请右键点击 Refract，
+> 选择**打开**，然后确认安全提示。
+
+## 技术栈
+
+<p align="left">
+  <img src="https://img.shields.io/badge/Tauri-5316D4?style=flat-square&logo=tauri&logoColor=white" alt="Tauri" />
+  <img src="https://img.shields.io/badge/React-5316D4?style=flat-square&logo=react&logoColor=white" alt="React" />
+  <img src="https://img.shields.io/badge/TypeScript-5316D4?style=flat-square&logo=typescript&logoColor=white" alt="TypeScript" />
+  <img src="https://img.shields.io/badge/Rust-5316D4?style=flat-square&logo=rust&logoColor=white" alt="Rust" />
+  <img src="https://img.shields.io/badge/Tailwind_CSS-5316D4?style=flat-square&logo=tailwindcss&logoColor=white" alt="Tailwind CSS" />
+</p>
+
+React 渲染层负责启动器体验。Tauri 和 Rust 提供原生外壳、安全凭据存储、下载、文件操作和平台集成。
+
+## 从源码构建
+
+### 前置要求
+
+* [Node.js](https://nodejs.org/) 20 或更高版本
+* [pnpm](https://pnpm.io/) 9 或更高版本
+* [Rust](https://www.rust-lang.org/tools/install) stable
+* 对应操作系统的 [Tauri 前置依赖](https://v2.tauri.app/start/prerequisites/)
+
+Windows 打包还需要 WebView2 和 Microsoft C++ 构建工具。
+
+### 环境搭建
+
+```bash
+git clone https://github.com/RefractMC/Refract_MC.git
+cd Refract_MC
+pnpm install
+pnpm dev
+```
+
+生成本地未签名构建：
+
+```bash
+pnpm build
+```
+
+有关验证命令、签名构建、项目规范和 pull request 指南，请参见 [CONTRIBUTING.md](../CONTRIBUTING.md)。
+
+<details>
+<summary><strong>仓库结构</strong></summary>
+
+* `apps/renderer` 包含共享的 React 渲染层。
+* `apps/tauri` 包含 Tauri 外壳和 Rust 后端。
+* `apps/electron-bridge` 将旧版 Electron 安装迁移到 Tauri。
+* `packages/core` 包含共享的启动器逻辑。
+* `packages/plugin-api` 包含公共插件 API。
+* `locales` 包含翻译文件。
+* `docs` 包含项目文档。
+
+</details>
+
+## 翻译
+
+Refract 将用户界面字符串存放在 [`locales`](../locales) 目录中。要添加新语言，请复制 `locales/en.json`，以 BCP 47 语言标签命名，翻译所有值，并保持每个 JSON 键不变。
+
+[翻译指南](../locales/README.md) 说明了语言注册、
+参数化字符串、验证和 pull request 命名规范。
+
+## 社区与支持
+
+* 通过 [GitHub Issues](https://github.com/RefractMC/Refract_MC/issues) 报告可复现的 bug。
+* 加入 [Refract Discord](https://discord.gg/tE8s5VaWmS) 寻求社区帮助、参与项目讨论。
+* 报告漏洞前请阅读 [安全策略](../SECURITY.md)。
+* 提交 pull request 前请阅读 [贡献指南](../CONTRIBUTING.md)。
+
+<p align="left">
+  <a href="https://discord.gg/tE8s5VaWmS">
+    <img src="https://discordapp.com/api/guilds/1507409148331954408/widget.png?style=banner3" alt="加入 Refract Discord" />
+  </a>
+</p>
+
+## 许可协议
+
+Refract 采用 [GNU General Public License v3.0](../LICENSE) 许可证。

--- a/locales/README.md
+++ b/locales/README.md
@@ -22,6 +22,23 @@ All launcher UI strings live here as JSON files, one per language.
 
 5. Open a **Pull Request** with the title `i18n: add [language name] translation`.
 
+## Translating the README
+
+1. **Copy** the root `README.md` to `docs/README.<lang>.md`, using the [BCP 47 language tag](https://en.wikipedia.org/wiki/IETF_language_tag) for your language (e.g. `docs/README.zh-CN.md`).
+2. **Translate** the content. Keep links, badges, code blocks, and brand names intact. Prefix repo-relative paths with `../` — the file lives one level deeper (e.g. `LICENSE` → `../LICENSE`). Absolute URLs are unchanged.
+3. **Add a language link** to the root `README.md`, right below the tagline. Use the language's [endonym](https://en.wikipedia.org/wiki/Endonym_and_exonym) (its name in that language) as the link text, prefixed with a `🌐` glyph — e.g. `简体中文` for Simplified Chinese:
+   ```html
+   <p align="center">
+     🌐 <a href="docs/README.zh-CN.md">简体中文</a>
+   </p>
+   ```
+4. **Add a link back** to the root `README.md` at the top of the translated file:
+   ```html
+   <p align="center">
+     🌐 <a href="../README.md">English</a>
+   </p>
+   ```
+
 ## String format
 
 ### Plain strings


### PR DESCRIPTION
Adds the first translated README (Simplified Chinese) and introduces a `docs/` 
directory for project documentation. Future translated READMEs follow the same 
`docs/README.<lang>.md` convention.

- **New** `docs/README.zh-CN.md` — Simplified Chinese translation of the root `README.md`.
- **README.md** — added `🌐 简体中文` language link below the tagline and listed 
  `docs` in the Repository layout.
- **locales/README.md** — added a "Translating the README" section covering naming, 
  the `../` path-prefix, and the language-link convention (single `🌐` glyph, 
  `|`-separated endonyms, English back-link only, no cross-links between sibling 
  translations).

`docs/` is a general project documentation directory, not a README-translations-only 
folder. The "where translated READMEs go" guidance lives in `locales/README.md` 
because that's the file contributors already read when adding a new language.

Docs-only, no code or app behavior changes.