### PR TITLE
feat: add Discord Rich Presence toggle in Privacy settings

### DIFF
--- a/apps/renderer/src/renderer/src/env.d.ts
+++ b/apps/renderer/src/renderer/src/env.d.ts
@@ -49,6 +49,7 @@ declare global {
           analyticsEnabled?: boolean
           analyticsNoticeShown?: boolean
           migrationNotice120Shown?: boolean
+          disableDiscordPresence?: boolean
           systemRamGb?: number
           curseforgeApiKey?: string
           curseforgeApiKeyConfigured?: boolean

--- a/apps/renderer/src/renderer/src/lib/api.ts
+++ b/apps/renderer/src/renderer/src/lib/api.ts
@@ -48,6 +48,7 @@ const DEFAULT_CONFIG: AppConfig = {
   defaultMemoryMb: 2048,
   onboardingDone: false,
   migrationNotice120Shown: false,
+  disableDiscordPresence: false,
   accounts: [],
 }
 

--- a/apps/renderer/src/renderer/src/routes/settings/index.tsx
+++ b/apps/renderer/src/renderer/src/routes/settings/index.tsx
@@ -735,6 +735,12 @@ function Settings() {
                   <SegmentButton active={analyticsDisabled || config?.analyticsEnabled === false} disabled={analyticsDisabled} onClick={() => { if (analyticsDisabled) return; api.config.set('analyticsEnabled', false).catch(() => {}); setConfig(c => c ? { ...c, analyticsEnabled: false } : c); showToast(t.privacy.analyticsOff) }}>{t.settings.off}</SegmentButton>
                 </Segmented>
               </Field>
+              <Field label={t.privacy.disableDiscordPresence} note={t.privacy.disableDiscordPresenceNote}>
+                <Segmented>
+                  <SegmentButton active={config?.disableDiscordPresence !== true} disabled={false} onClick={() => { api.config.set('disableDiscordPresence', false).catch(() => {}); setConfig(c => c ? { ...c, disableDiscordPresence: false } : c); showToast(t.privacy.disableDiscordPresenceOn) }}>{t.settings.on}</SegmentButton>
+                  <SegmentButton active={config?.disableDiscordPresence === true} disabled={false} onClick={() => { api.config.set('disableDiscordPresence', true).catch(() => {}); setConfig(c => c ? { ...c, disableDiscordPresence: true } : c); showToast(t.privacy.disableDiscordPresenceOff) }}>{t.settings.off}</SegmentButton>
+                </Segmented>
+              </Field>
             </div>
           </Panel>
 

--- a/apps/tauri/src-tauri/src/config.rs
+++ b/apps/tauri/src-tauri/src/config.rs
@@ -26,6 +26,7 @@ fn defaults() -> Value {
         "analyticsEnabled": true,
         "analyticsNoticeShown": false,
         "migrationNotice120Shown": false,
+        "disableDiscordPresence": false,
         "accounts": []
     })
 }

--- a/apps/tauri/src-tauri/src/discord.rs
+++ b/apps/tauri/src-tauri/src/discord.rs
@@ -1,4 +1,4 @@
-use serde_json::json;
+use serde_json::{json, Value};
 use std::collections::HashMap;
 use std::io::Write;
 use std::sync::{Mutex, OnceLock};
@@ -111,7 +111,7 @@ fn connect_ipc() -> Option<DiscordIpc> {
     for dir in dirs {
         for index in 0..10 {
             let path = format!("{dir}/discord-ipc-{index}");
-            if let Ok(stream) = std::os::unix::net::UnixStream::connect(path) {
+            if let Ok(stream) = std::os::unix::net::UnixStream::connect(&path) {
                 return Some(DiscordIpc::Unix(stream));
             }
         }
@@ -143,6 +143,14 @@ pub fn set_game_activity(
     mc_version: &str,
     mod_loader: Option<&str>,
 ) {
+    if crate::config::read()
+        .get("disableDiscordPresence")
+        .and_then(Value::as_bool)
+        .unwrap_or(false)
+    {
+        return;
+    }
+
     let Ok(mut state) = state().lock() else {
         return;
     };

--- a/locales/en.json
+++ b/locales/en.json
@@ -964,6 +964,10 @@
     "analyticsUnavailable": "Analytics is disabled in the Tauri build until telemetry secret injection is ported. No analytics events are sent from this build.",
     "analyticsOn": "Analytics enabled",
     "analyticsOff": "Analytics disabled",
+    "disableDiscordPresence": "Discord Rich Presence",
+    "disableDiscordPresenceNote": "Show what you're playing on Discord when a game is launched.",
+    "disableDiscordPresenceOn": "Discord Rich Presence enabled",
+    "disableDiscordPresenceOff": "Discord Rich Presence disabled",
     "noticeText": "Refract collects anonymous usage analytics to help improve the app. No personal data is collected — you can turn this off any time in Settings → Privacy.",
     "noticeDismiss": "Got it",
     "noticeOpenSettings": "Privacy settings"

--- a/locales/zh-CN.json
+++ b/locales/zh-CN.json
@@ -949,6 +949,10 @@
     "analyticsUnavailable": "在 Tauri 构建中，分析功能已禁用，直至遥测密钥注入功能完成移植。此构建不会发送任何分析事件。",
     "analyticsOn": "分析已启用",
     "analyticsOff": "分析已禁用",
+    "disableDiscordPresence": "Discord 游戏状态",
+    "disableDiscordPresenceNote": "启动游戏时在 Discord 上显示正在游玩的内容。",
+    "disableDiscordPresenceOn": "Discord 游戏状态已启用",
+    "disableDiscordPresenceOff": "Discord 游戏状态已禁用",
     "noticeText": "Refract 收集匿名使用分析数据以帮助改进应用。不收集个人数据 — 你可以随时在设置 → 隐私中关闭。",
     "noticeDismiss": "知道了",
     "noticeOpenSettings": "隐私设置"


### PR DESCRIPTION
- Add disableDiscordPresence config key (default: false)
- Guard set_game_activity with config check to skip RPC when disabled
- Add on/off toggle UI in Settings > Privacy panel
- Add locale keys for en and zh-CN