### PR TITLE
fix: read Discord READY frame after handshake, drain socket to prevent disconnect

### DIFF
--- a/apps/tauri/src-tauri/src/config.rs
+++ b/apps/tauri/src-tauri/src/config.rs
@@ -111,7 +111,15 @@ pub fn config_set(key: String, value: Value) -> Result<Value, String> {
         .as_object_mut()
         .ok_or_else(|| "config root is not an object".to_string())?;
     let _: &mut Map<String, Value> = map;
+    let should_clear_discord = key == "disableDiscordPresence" && value.as_bool() == Some(true);
+    let should_resume_discord = key == "disableDiscordPresence" && value.as_bool() == Some(false);
     map.insert(key, value);
     save(&cfg)?;
+    if should_clear_discord {
+        crate::discord::clear_all_activity();
+    }
+    if should_resume_discord {
+        crate::discord::resume_all_activity();
+    }
     Ok(cfg)
 }

--- a/apps/tauri/src-tauri/src/discord.rs
+++ b/apps/tauri/src-tauri/src/discord.rs
@@ -1,6 +1,6 @@
 use serde_json::{json, Value};
 use std::collections::HashMap;
-use std::io::Write;
+use std::io::{Read, Write};
 use std::sync::{Mutex, OnceLock};
 use std::time::{SystemTime, UNIX_EPOCH};
 use uuid::Uuid;
@@ -15,7 +15,14 @@ fn state() -> &'static Mutex<DiscordState> {
 #[derive(Default)]
 struct DiscordState {
     ipc: Option<DiscordIpc>,
-    starts: HashMap<String, i64>,
+    running: HashMap<String, ActivityInfo>,
+}
+
+struct ActivityInfo {
+    start: i64,
+    instance_name: String,
+    mc_version: String,
+    mod_loader: Option<String>,
 }
 
 enum DiscordIpc {
@@ -41,6 +48,17 @@ impl Write for DiscordIpc {
             DiscordIpc::Windows(file) => file.flush(),
             #[cfg(unix)]
             DiscordIpc::Unix(stream) => stream.flush(),
+        }
+    }
+}
+
+impl Read for DiscordIpc {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        match self {
+            #[cfg(windows)]
+            DiscordIpc::Windows(file) => file.read(buf),
+            #[cfg(unix)]
+            DiscordIpc::Unix(stream) => stream.read(buf),
         }
     }
 }
@@ -80,6 +98,62 @@ fn write_frame(
     frame.extend((body.len() as u32).to_le_bytes());
     frame.extend(body);
     ipc.write_all(&frame).map_err(|e| e.to_string())
+}
+
+fn activity_payload(
+    instance_name: &str,
+    mc_version: &str,
+    mod_loader: Option<&str>,
+    start: i64,
+) -> serde_json::Value {
+    json!({
+        "cmd": "SET_ACTIVITY",
+        "args": {
+            "pid": std::process::id(),
+            "activity": {
+                "details": instance_name,
+                "state": format!("MC {}{}", mc_version, loader_label(mod_loader)),
+                "timestamps": { "start": start },
+                "assets": {
+                    "large_image": "grass_block",
+                    "large_text": "Refract Launcher",
+                },
+                "instance": false,
+            },
+        },
+        "nonce": Uuid::new_v4().to_string(),
+    })
+}
+
+fn read_frame(ipc: &mut DiscordIpc) -> Result<(u32, serde_json::Value), String> {
+    let mut header = [0u8; 8];
+    ipc.read_exact(&mut header).map_err(|e| e.to_string())?;
+    let opcode = u32::from_le_bytes([header[0], header[1], header[2], header[3]]);
+    let length = u32::from_le_bytes([header[4], header[5], header[6], header[7]]) as usize;
+    let mut body = vec![0u8; length];
+    ipc.read_exact(&mut body).map_err(|e| e.to_string())?;
+    let payload: serde_json::Value = serde_json::from_slice(&body).map_err(|e| e.to_string())?;
+    Ok((opcode, payload))
+}
+
+fn is_ready_event(opcode: u32, payload: &serde_json::Value) -> bool {
+    opcode == 1
+        && payload.get("cmd").and_then(|v| v.as_str()) == Some("DISPATCH")
+        && payload.get("evt").and_then(|v| v.as_str()) == Some("READY")
+}
+
+#[cfg(unix)]
+fn spawn_drain_reader(stream: &std::os::unix::net::UnixStream) {
+    if let Ok(mut clone) = stream.try_clone() {
+        std::thread::spawn(move || {
+            let mut buf = [0u8; 4096];
+            loop {
+                if clone.read(&mut buf).is_err() {
+                    break;
+                }
+            }
+        });
+    }
 }
 
 #[cfg(windows)]
@@ -124,17 +198,36 @@ fn ensure_connected(state: &mut DiscordState) -> bool {
         return true;
     }
     let Some(mut ipc) = connect_ipc() else {
+        eprintln!("[refract:discord] failed to connect to Discord IPC");
         return false;
     };
     let handshake = json!({
         "v": 1,
         "client_id": DISCORD_CLIENT_ID,
     });
-    if write_frame(&mut ipc, 0, handshake).is_err() {
+    if let Err(e) = write_frame(&mut ipc, 0, handshake) {
+        eprintln!("[refract:discord] handshake write failed: {e}");
         return false;
     }
-    state.ipc = Some(ipc);
-    true
+    match read_frame(&mut ipc) {
+        Ok((opcode, ref payload)) if is_ready_event(opcode, payload) => {
+            #[cfg(unix)]
+            #[allow(irrefutable_let_patterns)]
+            if let DiscordIpc::Unix(ref stream) = ipc {
+                spawn_drain_reader(stream);
+            }
+            state.ipc = Some(ipc);
+            true
+        }
+        Ok((opcode, _payload)) => {
+            eprintln!("[refract:discord] unexpected handshake response opcode {opcode}");
+            false
+        }
+        Err(e) => {
+            eprintln!("[refract:discord] handshake read failed: {e}");
+            false
+        }
+    }
 }
 
 pub fn set_game_activity(
@@ -155,33 +248,22 @@ pub fn set_game_activity(
         return;
     };
     let start = now_unix();
-    state.starts.insert(instance_id.to_string(), start);
+    let info = ActivityInfo {
+        start,
+        instance_name: instance_name.to_string(),
+        mc_version: mc_version.to_string(),
+        mod_loader: mod_loader.map(str::to_string),
+    };
+    state.running.insert(instance_id.to_string(), info);
     if !ensure_connected(&mut state) {
         return;
     }
 
-    let payload = json!({
-        "cmd": "SET_ACTIVITY",
-        "args": {
-            "pid": std::process::id(),
-            "activity": {
-                "details": instance_name,
-                "state": format!("MC {}{}", mc_version, loader_label(mod_loader)),
-                "timestamps": {
-                    "start": start,
-                },
-                "assets": {
-                    "large_image": "grass_block",
-                    "large_text": "Refract Launcher",
-                },
-                "instance": false,
-            },
-        },
-        "nonce": Uuid::new_v4().to_string(),
-    });
+    let payload = activity_payload(instance_name, mc_version, mod_loader, start);
 
     if let Some(ipc) = state.ipc.as_mut() {
-        if write_frame(ipc, 1, payload).is_err() {
+        if let Err(e) = write_frame(ipc, 1, payload) {
+            eprintln!("[refract:discord] SET_ACTIVITY write failed: {e}");
             state.ipc = None;
         }
     }
@@ -191,8 +273,8 @@ pub fn clear_game_activity(instance_id: &str) {
     let Ok(mut state) = state().lock() else {
         return;
     };
-    state.starts.remove(instance_id);
-    if !state.starts.is_empty() || !ensure_connected(&mut state) {
+    state.running.remove(instance_id);
+    if !state.running.is_empty() || !ensure_connected(&mut state) {
         return;
     }
 
@@ -206,8 +288,59 @@ pub fn clear_game_activity(instance_id: &str) {
     });
 
     if let Some(ipc) = state.ipc.as_mut() {
-        if write_frame(ipc, 1, payload).is_err() {
+        if let Err(e) = write_frame(ipc, 1, payload) {
+            eprintln!("[refract:discord] clear SET_ACTIVITY write failed: {e}");
             state.ipc = None;
+        }
+    }
+}
+
+pub fn clear_all_activity() {
+    let Ok(mut state) = state().lock() else {
+        return;
+    };
+    if !ensure_connected(&mut state) {
+        return;
+    }
+    let payload = json!({
+        "cmd": "SET_ACTIVITY",
+        "args": {
+            "pid": std::process::id(),
+            "activity": null,
+        },
+        "nonce": Uuid::new_v4().to_string(),
+    });
+    if let Some(ipc) = state.ipc.as_mut() {
+        let _ = write_frame(ipc, 1, payload);
+    }
+}
+
+pub fn resume_all_activity() {
+    let Ok(mut state) = state().lock() else {
+        return;
+    };
+    if state.running.is_empty() || !ensure_connected(&mut state) {
+        return;
+    }
+    let payloads: Vec<serde_json::Value> = state
+        .running
+        .values()
+        .map(|info| {
+            activity_payload(
+                &info.instance_name,
+                &info.mc_version,
+                info.mod_loader.as_deref(),
+                info.start,
+            )
+        })
+        .collect();
+    for payload in payloads {
+        if let Some(ipc) = state.ipc.as_mut() {
+            if let Err(e) = write_frame(ipc, 1, payload) {
+                eprintln!("[refract:discord] resume SET_ACTIVITY write failed: {e}");
+                state.ipc = None;
+                break;
+            }
         }
     }
 }


### PR DESCRIPTION
Refract never reads from the Discord IPC socket — it only writes. The
handshake is sent but the READY response (opcode 1) is never consumed,
and incoming frames like PINGs pile up in the receive buffer. This
prevents RPC from appearing on some Linux setups while others happen to
survive the session.

Diagnosed with a minimal standalone test program that connects, reads
the READY frame, sends SET_ACTIVITY, and keeps a drain loop alive. It
renders activity correctly on the affected machine; the existing code
does not.

Changes in discord.rs:
- Read the READY frame after handshake
- On Unix, spawn a drain reader thread (try_clone) to consume all
  incoming frames so the socket stays alive
- Store ActivityInfo per running instance; add clear_all_activity and
  resume_all_activity so toggling disableDiscordPresence immediately
  clears or restores RPC
- eprintln diagnostics on every failure path
- Extract activity_payload helper

Changes in config.rs:
- Wire config_set to clear_all_activity / resume_all_activity when
  the toggle changes state

Built and tested on standard Discord desktop 1.0.150 (Rocky Linux 10.2).