### PR TITLE
Add NixOS support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,7 @@ out
 # Rust / Tauri build output
 target
 apps/tauri/src-tauri/gen
+
+# Nix build output
+result
+result-*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+### Added
+
+* Added a Nix flake with native NixOS packaging, a Tauri development shell, bundled Java runtimes, and Minecraft runtime libraries.
+
+### Changed
+
+* Nix builds now defer application updates to Nix instead of offering an incompatible self-update.
+
 ## 1.3.4
 
 ### Added

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,6 +27,10 @@ cd Refract_MC
 pnpm install
 ```
 
+On NixOS, `nix develop` provides Node, pnpm, Rust, Tauri, the supported Java
+runtimes, and the native libraries needed by Refract and Minecraft. Run
+`pnpm install` after entering the shell.
+
 ## Run the app
 
 ```bash
@@ -71,6 +75,8 @@ For packaging changes:
 
 ```bash
 pnpm --filter @refract/tauri-poc build
+nix flake check
+nix build
 ```
 
 ## Pull request rules

--- a/PROJECT_KNOWLEDGE.md
+++ b/PROJECT_KNOWLEDGE.md
@@ -69,6 +69,7 @@ The most important architectural rule is: UI components call the stable `api.*` 
 | `locales` | Translation JSON | English is the schema/fallback; Ukrainian and Simplified Chinese are registered. |
 | `logo` | Brand and README assets | Includes icons and the current screenshot. |
 | `packaging/aur` | Arch User Repository package | Binary package consumes the stable RPM release asset. |
+| `flake.nix`, `nix/package.nix` | NixOS package and development shell | Builds the native app from source and supplies Java and Minecraft runtime libraries. |
 | `.github/workflows` | Build, audit, release, AUR, and Discord automation | CI uses Node 24 and pnpm 11. |
 | `README.md` | Product overview and public setup | Start here for users. |
 | `CONTRIBUTING.md` | Contributor rules and checks | Keep changes focused and report verification. |
@@ -402,6 +403,19 @@ pnpm format
 pnpm audit --prod
 ```
 
+NixOS package and development environment:
+
+```sh
+nix build
+nix develop
+```
+
+The Nix package builds Refract from source, exposes Java 8, 17, 21, and 25 to
+the launcher, and supplies the native libraries used by Minecraft. It disables
+the application self-updater because the Nix store is immutable; updates are
+performed through Nix. A desktop Secret Service provider remains required for
+authenticated accounts.
+
 `pnpm build` uses `tauri.local.conf.json`, disables updater artifact creation, and creates an unsigned local installer. `build:signed` uses production updater configuration and needs the Tauri signing secrets.
 
 ### Verification by change type
@@ -475,7 +489,7 @@ Never commit private signing material. The updater public key in `tauri.conf.jso
 > [!warning] Do not confuse historical code with the production runtime
 > Comments saying "Rust port of" refer to the Electron-to-Tauri migration. The current production native backend is Rust. Some TypeScript core files still contain Node process/filesystem logic and `packages/core/src/auth/index.ts` still throws `Not implemented`; those are not the live Tauri authentication path.
 
-- The package name `@refract/tauri-poc` and Cargo description still say proof-of-concept even though Tauri is production. Renaming affects scripts and release automation, so treat it as a deliberate migration.
+- The package name `@refract/tauri-poc` is historical even though Tauri is production. Renaming affects scripts and release automation, so treat it as a deliberate migration.
 - `packages/plugin-api` currently defines only `LauncherPlugin` and `PluginContext`; do not promise plugin loading without implementing discovery, sandboxing, lifecycle, and UI integration.
 - `locales/README.md` contains a few old path examples. The current files live under `apps/renderer/src/renderer/src/...`; verify paths against the tree.
 - Old source comments can describe earlier scope. Trust registered commands and current call paths over historical comments.

--- a/README.md
+++ b/README.md
@@ -116,7 +116,8 @@ curl -fsSL https://refractmc.net/install.sh | sh
 | Linux — Debian/Ubuntu | [Download `.deb`](https://github.com/RefractMC/Refract_MC/releases/latest/download/Refract-Linux-amd64.deb)            |
 | Linux — Fedora        | [Download `.rpm`](https://github.com/RefractMC/Refract_MC/releases/latest/download/Refract-Linux-x86_64.rpm)           |
 | Linux — Arch/AUR      | [`yay -S refract-launcher-bin`](https://aur.archlinux.org/packages/refract-launcher-bin)                               |
-| Other packages        | [View the latest release](https://github.com/RefractMC/Refract_MC/releases/latest)                                     |
+| Linux - NixOS          | `nix run github:RefractMC/Refract_MC`                                                                                  |
+| Other packages         | [View the latest release](https://github.com/RefractMC/Refract_MC/releases/latest)                                     |
 
 
 > [!NOTE]
@@ -162,6 +163,17 @@ Create a local unsigned build with:
 ```bash
 pnpm build
 ```
+
+On NixOS, the repository flake provides the native app and all required Java
+runtimes:
+
+```sh
+nix run github:RefractMC/Refract_MC
+```
+
+Contributors can enter the Tauri development environment with `nix develop`,
+then run `pnpm install` and the usual project commands. A Secret Service
+provider, such as GNOME Keyring or KWallet, is required for signed-in accounts.
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for verification commands, signed builds,
 project conventions, and pull request guidelines.

--- a/apps/renderer/src/renderer/src/components/layout/TitleBar.tsx
+++ b/apps/renderer/src/renderer/src/components/layout/TitleBar.tsx
@@ -62,6 +62,7 @@ export function TitleBar() {
   }, [])
 
   useEffect(() => {
+    if (!__APP_UPDATER_ENABLED__) return
     const unA = api.updater.onAvailable(({ version }) => {
       setUpdate({ version, phase: 'pending', percent: 0 })
     })

--- a/apps/renderer/src/renderer/src/env.d.ts
+++ b/apps/renderer/src/renderer/src/env.d.ts
@@ -15,6 +15,7 @@ export interface ExternalInstance {
 
 declare global {
   const __APP_VERSION__: string
+  const __APP_UPDATER_ENABLED__: boolean
   interface Window {
     api: {
       skins: {

--- a/apps/renderer/src/renderer/src/routes/settings/index.tsx
+++ b/apps/renderer/src/renderer/src/routes/settings/index.tsx
@@ -423,6 +423,7 @@ function Settings() {
   }, [])
 
   useEffect(() => {
+    if (!__APP_UPDATER_ENABLED__) return
     const unAvailable = api.updater.onAvailable(({ version }) => {
       setAppUpdate({ phase: 'available', version })
     })
@@ -537,7 +538,9 @@ function Settings() {
       case 'ready': return t.settings.appUpdateReady
       case 'installing': return t.settings.restartingForUpdate
       case 'error': return t.settings.appUpdateFailed(appUpdate.error ?? t.settings.unknownError)
-      default: return t.settings.appUpdatesNote
+      default: return __APP_UPDATER_ENABLED__
+        ? t.settings.appUpdatesNote
+        : t.settings.appUpdatesManaged
     }
   }
 
@@ -1174,18 +1177,20 @@ function Settings() {
               {appUpdateStatusText()}
             </div>
           </div>
-          <Button
-            variant={appUpdate.phase === 'ready' ? 'primary' : 'secondary'}
-            onClick={runAppUpdateAction}
-            disabled={
-              appUpdate.phase === 'checking'
-              || appUpdate.phase === 'downloading'
-              || appUpdate.phase === 'installing'
-            }
-            style={{ flexShrink:0 }}
-          >
-            {appUpdateButtonLabel()}
-          </Button>
+          {__APP_UPDATER_ENABLED__ && (
+            <Button
+              variant={appUpdate.phase === 'ready' ? 'primary' : 'secondary'}
+              onClick={runAppUpdateAction}
+              disabled={
+                appUpdate.phase === 'checking'
+                || appUpdate.phase === 'downloading'
+                || appUpdate.phase === 'installing'
+              }
+              style={{ flexShrink:0 }}
+            >
+              {appUpdateButtonLabel()}
+            </Button>
+          )}
         </div>
       </Panel>
 

--- a/apps/tauri/README.md
+++ b/apps/tauri/README.md
@@ -70,3 +70,10 @@ cd apps/tauri/src-tauri
 cargo fmt
 cargo check
 ```
+
+## NixOS
+
+From the repository root, run the packaged application with `nix run` or enter
+the development environment with `nix develop`. The package supplies Java 8,
+17, 21, and 25 plus the native libraries Minecraft needs on NixOS. Self-updates
+are disabled in this immutable build; update Refract through Nix instead.

--- a/apps/tauri/src-tauri/Cargo.toml
+++ b/apps/tauri/src-tauri/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "refract-tauri"
 version = "1.3.4"
-description = "Refract Minecraft Launcher (Tauri proof-of-concept)"
+description = "Refract Minecraft Launcher"
 edition = "2021"
 
 # The library Tauri runs; main.rs is a thin launcher around it (Tauri v2 layout).

--- a/apps/tauri/src-tauri/src/java.rs
+++ b/apps/tauri/src-tauri/src/java.rs
@@ -178,16 +178,12 @@ fn detect_uncached() -> Vec<Install> {
         add(probe(&PathBuf::from(jh).join("bin").join(JAVA_BIN)));
     }
 
-    // 2. PATH
-    let probe_cmd = if cfg!(windows) { "where" } else { "which" };
-    let mut cmd = Command::new(probe_cmd);
-    crate::procutil::hide_window(&mut cmd);
-    if let Ok(out) = cmd.arg("java").output() {
-        for line in String::from_utf8_lossy(&out.stdout).lines() {
-            let p = line.trim();
-            if !p.is_empty() {
-                add(probe(Path::new(p)));
-            }
+    // 2. PATH. Inspect every entry instead of asking which, which only
+    // returns the first Java on Unix. Nix packages expose several immutable
+    // runtimes on PATH so the launcher can select the correct major version.
+    if let Some(path) = std::env::var_os("PATH") {
+        for java_exe in java_candidates_on_path(&path) {
+            add(probe(&java_exe));
         }
     }
 
@@ -239,6 +235,12 @@ fn detect_uncached() -> Vec<Install> {
 
     found.sort_by(|a, b| b.version.cmp(&a.version));
     found
+}
+
+fn java_candidates_on_path(path: &std::ffi::OsStr) -> Vec<PathBuf> {
+    std::env::split_paths(path)
+        .map(|dir| dir.join(JAVA_BIN))
+        .collect()
 }
 
 /// Detected + managed installations, deduped by path, newest first.
@@ -357,8 +359,21 @@ fn required_for(mc_version: &str) -> u32 {
 
 #[cfg(test)]
 mod tests {
-    use super::{required_for, resolve_symlink_target, strip_safe_top_component};
-    use std::path::Path;
+    use super::{
+        java_candidates_on_path, required_for, resolve_symlink_target, strip_safe_top_component,
+        JAVA_BIN,
+    };
+    use std::path::{Path, PathBuf};
+
+    #[test]
+    fn discovers_every_java_runtime_exposed_on_path() {
+        let dirs = [PathBuf::from("jdk-8/bin"), PathBuf::from("jdk 21/bin")];
+        let path = std::env::join_paths(&dirs).unwrap();
+        assert_eq!(
+            java_candidates_on_path(&path),
+            dirs.map(|dir| dir.join(JAVA_BIN))
+        );
+    }
 
     #[test]
     fn maps_current_release_versions_to_expected_java() {

--- a/apps/tauri/src-tauri/tauri.conf.json
+++ b/apps/tauri/src-tauri/tauri.conf.json
@@ -41,6 +41,7 @@
   },
   "bundle": {
     "active": true,
+    "category": "Game",
     "createUpdaterArtifacts": true,
     "targets": "all",
     "macOS": {

--- a/apps/tauri/vite.renderer.config.ts
+++ b/apps/tauri/vite.renderer.config.ts
@@ -11,6 +11,7 @@ import { TanStackRouterVite } from '@tanstack/router-plugin/vite'
 const here = (p: string) => fileURLToPath(new URL(p, import.meta.url))
 const rendererRoot = here('../renderer/src/renderer')
 const appVersion: string = JSON.parse(readFileSync(here('../renderer/package.json'), 'utf8')).version
+const appUpdaterEnabled = process.env.REFRACT_UPDATER_ENABLED !== 'false'
 
 export default defineConfig({
   root: rendererRoot,
@@ -27,6 +28,7 @@ export default defineConfig({
   },
   define: {
     __APP_VERSION__: JSON.stringify(appVersion),
+    __APP_UPDATER_ENABLED__: JSON.stringify(appUpdaterEnabled),
   },
   clearScreen: false,
   server: {

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1786599213,
+        "narHash": "sha256-yNJd40f11EzXBjSByCB7IPpeFFAdeoSKKM67dGkfFoU=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "0e251e24a4f24e036a084b6b4b2d2491af4167f4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,85 @@
+{
+  description = "Refract Minecraft launcher";
+
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+
+  outputs =
+    { self, nixpkgs }:
+    let
+      supportedSystems = [
+        "x86_64-linux"
+        "aarch64-linux"
+      ];
+      forAllSystems = nixpkgs.lib.genAttrs supportedSystems;
+      pkgsFor = system: import nixpkgs { inherit system; };
+    in
+    {
+      packages = forAllSystems (
+        system:
+        let
+          pkgs = pkgsFor system;
+          refract = pkgs.callPackage ./nix/package.nix { src = self; };
+        in
+        {
+          inherit refract;
+          default = refract;
+        }
+      );
+
+      devShells = forAllSystems (
+        system:
+        let
+          pkgs = pkgsFor system;
+        in
+        {
+          default = pkgs.mkShell {
+            packages = with pkgs; [
+              cargo
+              cargo-tauri
+              fontconfig
+              jdk8
+              jdk17
+              jdk21
+              jdk25
+              nodejs_24
+              pkg-config
+              pnpm_11
+              rustc
+              xdg-utils
+              xrandr
+            ];
+
+            buildInputs = with pkgs; [
+              glib-networking
+              libayatana-appindicator
+              webkitgtk_4_1
+            ];
+
+            LD_LIBRARY_PATH = pkgs.lib.makeLibraryPath (
+              with pkgs;
+              [
+                addDriverRunpath.driverLink
+                alsa-lib
+                flite
+                libGL
+                libayatana-appindicator
+                libjack2
+                libpulseaudio
+                libx11
+                libxcursor
+                libxext
+                libxrandr
+                libxxf86vm
+                pipewire
+                stdenv.cc.cc
+                udev
+                webkitgtk_4_1
+              ]
+            );
+          };
+        }
+      );
+
+      formatter = forAllSystems (system: (pkgsFor system).nixfmt-tree);
+    };
+}

--- a/locales/en.json
+++ b/locales/en.json
@@ -562,6 +562,7 @@
     "appLogs": "Application Logs",
     "appUpdates": "Application Updates",
     "appUpdatesNote": "Check GitHub Releases for a newer signed version of Refract.",
+    "appUpdatesManaged": "Updates are managed by your system package manager.",
     "installedAppVersion": "Installed version: {{version}}",
     "checkForUpdates": "Check for updates",
     "checkingForUpdates": "Checking for updates...",

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -1,0 +1,129 @@
+{
+  lib,
+  stdenv,
+  src,
+  rustPlatform,
+  cargo-tauri,
+  fetchPnpmDeps,
+  nodejs_24,
+  pnpm_11,
+  pnpmConfigHook,
+  pkg-config,
+  wrapGAppsHook4,
+  glib-networking,
+  libayatana-appindicator,
+  webkitgtk_4_1,
+  addDriverRunpath,
+  alsa-lib,
+  flite,
+  fontconfig,
+  jdk8,
+  jdk17,
+  jdk21,
+  jdk25,
+  libGL,
+  libjack2,
+  libpulseaudio,
+  libx11,
+  libxcursor,
+  libxext,
+  libxrandr,
+  libxxf86vm,
+  pipewire,
+  udev,
+  xdg-utils,
+  xrandr,
+  jdks ? [
+    jdk8
+    jdk17
+    jdk21
+    jdk25
+  ],
+}:
+
+let
+  runtimeLibraries = [
+    addDriverRunpath.driverLink
+
+    # LWJGL / GLFW
+    libGL
+    libx11
+    libxcursor
+    libxext
+    libxrandr
+    libxxf86vm
+    stdenv.cc.cc
+
+    # Minecraft audio, narration, and device discovery
+    alsa-lib
+    flite
+    libjack2
+    libpulseaudio
+    pipewire
+    udev
+  ];
+in
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "refract";
+  version =
+    (builtins.fromTOML (builtins.readFile (src + "/apps/tauri/src-tauri/Cargo.toml"))).package.version;
+
+  inherit src;
+
+  cargoRoot = "apps/tauri/src-tauri";
+  buildAndTestSubdir = finalAttrs.cargoRoot;
+  cargoLock.lockFile = src + "/apps/tauri/src-tauri/Cargo.lock";
+
+  pnpmDeps = fetchPnpmDeps {
+    inherit (finalAttrs) pname version src;
+    pnpm = pnpm_11;
+    fetcherVersion = 4;
+    hash = "sha256-02RHViN1e4IdCekrgl/q6m2lgLnM0wCQW8MJw8C/AKc=";
+  };
+
+  nativeBuildInputs = [
+    cargo-tauri.hook
+    nodejs_24
+    pkg-config
+    pnpmConfigHook
+    pnpm_11
+    wrapGAppsHook4
+  ];
+
+  buildInputs = [
+    glib-networking
+    libayatana-appindicator
+    webkitgtk_4_1
+  ];
+
+  env.REFRACT_UPDATER_ENABLED = "false";
+
+  postPatch = ''
+    substituteInPlace apps/tauri/src-tauri/tauri.conf.json \
+      --replace-fail '"createUpdaterArtifacts": true' '"createUpdaterArtifacts": false'
+  '';
+
+  preFixup = ''
+    gappsWrapperArgs+=(
+      --prefix PATH : ${
+        lib.makeBinPath (
+          jdks
+          ++ [
+            fontconfig
+            xdg-utils
+            xrandr
+          ]
+        )
+      }
+      --set LD_LIBRARY_PATH ${lib.makeLibraryPath runtimeLibraries}
+    )
+  '';
+
+  meta = {
+    description = "Fast, open-source Minecraft launcher built with Tauri and React";
+    homepage = "https://refractmc.net";
+    license = lib.licenses.gpl3Only;
+    mainProgram = "refract-tauri";
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
## Summary

- add a reproducible Nix flake and native Tauri package for x86_64-linux and aarch64-linux
- provide Java 8, 17, 21, and 25 plus the native libraries required by Minecraft and the launcher
- discover every Java runtime exposed through `PATH`
- let Nix manage updates and document the NixOS user, development, and security-service workflows

## Why

Refract did not have a supported NixOS installation or development path. Its runtime also needs multiple Java versions and native libraries that are not implicitly available on NixOS.

## User and developer impact

Users can run Refract with `nix run github:RefractMC/Refract_MC`. Contributors can enter a complete environment with `nix develop`. Nix builds display that updates are managed by the system package manager instead of invoking the Tauri updater.

## Validation

- full `nix build .#refract` package build
- 27 Rust tests passed; 1 network test ignored
- `nix flake check --all-systems --no-build`
- `nix build .#refract --no-link --dry-run`
- `pnpm --filter @refract/renderer typecheck`
- `cargo fmt --check`
- `cargo check`
- `pnpm --filter @refract/tauri-poc tauri info`
- confirmed all four JDKs in `nix develop`
- confirmed the packaged executable has no missing shared libraries
- `git diff --check`

## Notes

An interactive GUI launch on a physical NixOS desktop has not yet been exercised. The cold Nix closure is approximately 3.1 GB because it includes four JDKs and the required Minecraft runtime libraries.
